### PR TITLE
Return empty menu if NewsBlog not enabled as an application

### DIFF
--- a/aldryn_newsblog/menu.py
+++ b/aldryn_newsblog/menu.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 from django.utils.translation import (
     get_language_from_request,
@@ -32,7 +33,10 @@ class NewsBlogMenu(CMSAttachMenu):
         articles = self.get_queryset(request).active_translations(language)
 
         if hasattr(self, 'instance') and self.instance:
-            app = apphook_pool.get_apphook(self.instance.application_urls)
+            try:
+                app = apphook_pool.get_apphook(self.instance.application_urls)
+            except ImproperlyConfigured:
+                return nodes
             config = app.get_config(self.instance.application_namespace)
             if config:
                 articles = articles.filter(app_config=config)


### PR DESCRIPTION
A customer accidentally enabled Aldryn NewsBlog as an attached menu but not as an application.

![image](https://cloud.githubusercontent.com/assets/1207350/12372736/6c81b9e4-bc2f-11e5-841c-4d30624e85e6.png)

(This error scenario requires that NewsBlog is not the app for any other page either.)

Page loads tried to generate navigation, which blew up generating the menu.  I edited the template on production to disable navigation in order to find and fix the misconfiguration.

The exception:

```
File "/var/www/FOO/env/lib/python3.4/site-packages/classytags/core.py", line 106, in render
    return self.render_tag(context, **kwargs)
  File "/var/www/FOO/env/lib/python3.4/site-packages/classytags/helpers.py", line 86, in render_tag
    data = context.new(self.get_context(context, **kwargs))
  File "/var/www/FOO/env/lib/python3.4/site-packages/menus/templatetags/menu_tags.py", line 133, in get_context
    nodes = menu_pool.get_nodes(request, namespace, root_id)
  File "/var/www/FOO/env/lib/python3.4/site-packages/menus/menu_pool.py", line 256, in get_nodes
    nodes = self._build_nodes(request, site_id)
  File "/var/www/FOO/env/lib/python3.4/site-packages/menus/menu_pool.py", line 215, in _build_nodes
    nodes = menu.get_nodes(request)
  File "/var/www/FOO/env/lib/python3.4/site-packages/aldryn_newsblog/menu.py", line 35, in get_nodes
    app = apphook_pool.get_apphook(self.instance.application_urls)
  File "/var/www/FOO/env/lib/python3.4/site-packages/cms/apphook_pool.py", line 97, in get_apphook
    raise ImproperlyConfigured('No registered apphook %r found' % app_name)
django.core.exceptions.ImproperlyConfigured: No registered apphook '' found
```

I assume this could happen in many different CMS plugins; I didn't see such protection in a couple of others I examined.
