### PR TITLE
pin django-taggit version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIREMENTS = [
     'django-filer>=0.9.9',
     'django-parler>=1.8.1',
     'django-sortedm2m>=1.2.2,!=1.3.0,!=1.3.1',
-    'django-taggit',
+    'django-taggit<=0.22.2',
     'lxml',
     'pytz',
     'six',


### PR DESCRIPTION
This is needed, otherwise there is a dependency compatibility if one tries to use aldryn-newsblog within the Divio cloud. django-taggit above 0.22.2 requires Django>=1.11

Fixes #497